### PR TITLE
htaccess: redirect v2.3 URLs to latest-release (v2.3 publication stopped)

### DIFF
--- a/htaccess/.htaccess.public.sh
+++ b/htaccess/.htaccess.public.sh
@@ -6,6 +6,8 @@
 # with a starts-with rule should begin with "^/docs".
 
 #///////////////////////////////////////
+## Obsolete Multi-Versioned Site URLs
+
 # Redirect old versioned sections URLs (<section>/<version>/ where <version> is
 # "vX.Y" or "latest-release") to <version>/<section>
 # <section>/vX.Y/* > latest-release/)
@@ -17,13 +19,17 @@ RedirectMatch 301 ^/(docs)/(concepts|intro|reference|specs|tutorials)/(v[0-9]\.[
 RedirectMatch 301 ^/(docs)/(concepts|intro|reference|release-notes|specs|tutorials)(|/.*)$ https://www.iguazio.com/$1/latest-release/$2/$3
 
 #///////////////////////////////////////
-# Redirect latest-release version-number URLs (/v<X.Y/X.Y.Z (latest release)>/*
-# > /latest-release/*)
+## Latest-release Version-Number URLs
+#(/v<X.Y/X.Y.Z (latest release)>/* > /latest-release/*)
 # [TODO-NEW-VER] Update the hardcoded version number in the source URL.
 RedirectMatch 301 ^/(docs)/v2.8(\.[0-9]|)(|/.*)$ https://www.iguazio.com/$1/latest-release/$3
 
 #///////////////////////////////////////
-## Relocated-Pages Redirects
+## Removed Old-Release Doc Sites (No Longer Published)
+RedirectMatch 301 ^/(docs)/v2.3(|.[0-9])(|/.*)$ https://www.iguazio.com/$1/latest-release/
+
+#///////////////////////////////////////
+## Relocated Pages
 # [ci-redirect-from-ver-site] [InfraInfo] See gulpfile.js in the doc-site repo.
 
 #---------------------------------------

--- a/htaccess/.htaccess.staging.dev.sh
+++ b/htaccess/.htaccess.staging.dev.sh
@@ -6,6 +6,8 @@
 # with a starts-with rule should begin with "^/docs-dev/".
 
 #///////////////////////////////////////
+## Obsolete Multi-Versioned Site URLs
+
 # Redirect old versioned sections URLs (<section>/<version>/ where <version> is
 # "vX.Y" or "latest-release") to <version>/<section>
 # <section>/vX.Y/* > latest-release/)
@@ -17,13 +19,17 @@ RedirectMatch 301 ^/(docs-dev)/(concepts|intro|reference|specs|tutorials)/(v[0-9
 RedirectMatch 301 ^/(docs-dev)/(concepts|intro|reference|release-notes|specs|tutorials)(|/.*)$ https://igzdocsdev.wpengine.com/$1/latest-release/$2/$3
 
 #///////////////////////////////////////
-# Redirect latest-release version-number URLs (/v<X.Y/X.Y.Z (latest release)>/*
-# > /latest-release/*)
+## Latest-release Version-Number URLs
+#(/v<X.Y/X.Y.Z (latest release)>/* > /latest-release/*)
 # [TODO-NEW-VER] Update the hardcoded version number in the source URL.
 RedirectMatch 301 ^/(docs-dev)/v2.8(\.[0-9]|)(|/.*)$ https://igzdocsdev.wpengine.com/$1/latest-release/$3
 
 #///////////////////////////////////////
-## Relocated-Pages Redirects
+## Removed Old-Release Doc Sites (No Longer Published)
+RedirectMatch 301 ^/(docs-dev)/v2.3(|.[0-9])(|/.*)$ https://www.igzdocsdev.wpengine.com/$1/latest-release/
+
+#///////////////////////////////////////
+## Relocated Pages
 # [ci-redirect-from-ver-site] [InfraInfo] See gulpfile.js in the doc-site repo.
 
 #---------------------------------------

--- a/htaccess/.htaccess.staging.sh
+++ b/htaccess/.htaccess.staging.sh
@@ -6,6 +6,8 @@
 # with a starts-with rule should begin with "^/docs".
 
 #///////////////////////////////////////
+## Obsolete Multi-Versioned Site URLs
+
 # Redirect old versioned sections URLs (<section>/<version>/ where <version> is
 # "vX.Y" or "latest-release") to <version>/<section>
 # <section>/vX.Y/* > latest-release/)
@@ -17,13 +19,17 @@ RedirectMatch 301 ^/(docs)/(concepts|intro|reference|specs|tutorials)/(v[0-9]\.[
 RedirectMatch 301 ^/(docs)/(concepts|intro|reference|release-notes|specs|tutorials)(|/.*)$ https://igzdocsdev.wpengine.com/$1/latest-release/$2/$3
 
 #///////////////////////////////////////
-# Redirect latest-release version-number URLs (/v<X.Y/X.Y.Z (latest release)>/*
-# > /latest-release/*)
+## Latest-release Version-Number URLs
+#(/v<X.Y/X.Y.Z (latest release)>/* > /latest-release/*)
 # [TODO-NEW-VER] Update the hardcoded version number in the source URL.
 RedirectMatch 301 ^/(docs)/v2.8(\.[0-9]|)(|/.*)$ https://igzdocsdev.wpengine.com/$1/latest-release/$3
 
 #///////////////////////////////////////
-## Relocated-Pages Redirects
+## Removed Old-Release Doc Sites (No Longer Published)
+RedirectMatch 301 ^/(docs)/v2.3(|.[0-9])(|/.*)$ https://www.igzdocsdev.wpengine.com/$1/latest-release/
+
+#///////////////////////////////////////
+## Relocated Pages
 # [ci-redirect-from-ver-site] [InfraInfo] See gulpfile.js in the doc-site repo.
 
 #---------------------------------------


### PR DESCRIPTION
Merged to `master` first, by mistake, in PR #17.