### PR TITLE
.htaccess: Add URL redirects for AWS & Azure cloud-installation how-tos file renaming (v2.8 latest-release)

### DIFF
--- a/htaccess/.htaccess.public.sh
+++ b/htaccess/.htaccess.public.sh
@@ -83,3 +83,23 @@ RedirectMatch 301 ^/(docs/[^/]+)/tutorials/getting-started/additional-resources(
 # DNS & SMTP setup intro pages moved to a howto/ subdirectory
 RedirectMatch 301 ^/(docs/latest-release/intro/setup)/(dns|smtp)(|/.*)$ https://www.iguazio.com/$1/howto/$2
 
+#=======================================
+## Pages Added and Renamed (Moved) in V2.8.0
+# The following redirects are for pages that were added in v2.8.0, when it was
+# the latest-release doc, and then renamed (=> URLs changed) shortly after the
+# initial publication. => It's sufficient to apply the rules to latest-release.
+
+# Cloud-installation how-tos
+# calculate-resources/ > resources-calculate/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/calculate-resources(|/)$ https://www.iguazio.com/$1/resources-calculate/
+# configure-security-groups/ > network-security-groups-cfg/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-security-groups(|/)$ https://www.iguazio.com/$1/network-security-groups-cfg/
+# configure-subnet-public-ips-alloc/ > subnet-public-ips-alloc-cfg/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-subnet-public-ips-alloc(|/)$ https://www.iguazio.com/$1/subnet-public-ips-alloc-cfg/
+# create-iam-role/ > iam-role-n-instance-profile-create/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-role(|/)$ https://www.iguazio.com/$1/iam-role-n-instance-profile-create/
+# create-iam-user/ > iam-user-create/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-user(|/)$ https://www.iguazio.com/$1/iam-user-create/
+# prepare-install/ > pre-install-steps/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/prepare-install(|/)$ https://www.iguazio.com/$1/pre-install-steps/
+

--- a/htaccess/.htaccess.staging.dev.sh
+++ b/htaccess/.htaccess.staging.dev.sh
@@ -60,3 +60,23 @@ RedirectMatch 301 ^/(docs-dev/[^/]+)/tutorials/getting-started/additional-resour
 # DNS & SMTP setup intro pages moved to a howto/ subdirectory
 RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup)/(dns|smtp)(|/.*)$ https://igzdocsdev.wpengine.com/$1/howto/$2
 
+#=======================================
+## Pages Added and Renamed (Moved) in V2.8.0
+# The following redirects are for pages that were added in v2.8.0, when it was
+# the latest-release doc, and then renamed (=> URLs changed) shortly after the
+# initial publication. => It's sufficient to apply the rules to latest-release.
+
+# Cloud-installation how-tos
+# calculate-resources/ > resources-calculate/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/calculate-resources(|/)$ https://igzdocsdev.wpengine.com/$1/resources-calculate/
+# configure-security-groups/ > network-security-groups-cfg/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-security-groups(|/)$ https://igzdocsdev.wpengine.com/$1/network-security-groups-cfg/
+# configure-subnet-public-ips-alloc/ > subnet-public-ips-alloc-cfg/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-subnet-public-ips-alloc(|/)$ https://igzdocsdev.wpengine.com/$1/subnet-public-ips-alloc-cfg/
+# create-iam-role/ > iam-role-n-instance-profile-create/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-role(|/)$ https://igzdocsdev.wpengine.com/$1/iam-role-n-instance-profile-create/
+# create-iam-user/ > iam-user-create/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-user(|/)$ https://igzdocsdev.wpengine.com/$1/iam-user-create/
+# prepare-install/ > pre-install-steps/
+RedirectMatch 301 ^/(docs-dev/latest-release/intro/setup/cloud/(aws|azure)/howto)/prepare-install(|/)$ https://igzdocsdev.wpengine.com/$1/pre-install-steps/
+

--- a/htaccess/.htaccess.staging.sh
+++ b/htaccess/.htaccess.staging.sh
@@ -83,3 +83,23 @@ RedirectMatch 301 ^/(docs/[^/]+)/tutorials/getting-started/additional-resources(
 # DNS & SMTP setup intro pages moved to a howto/ subdirectory
 RedirectMatch 301 ^/(docs/latest-release/intro/setup)/(dns|smtp)(|/.*)$ https://igzdocsdev.wpengine.com/$1/howto/$2
 
+#=======================================
+## Pages Added and Renamed (Moved) in V2.8.0
+# The following redirects are for pages that were added in v2.8.0, when it was
+# the latest-release doc, and then renamed (=> URLs changed) shortly after the
+# initial publication. => It's sufficient to apply the rules to latest-release.
+
+# Cloud-installation how-tos
+# calculate-resources/ > resources-calculate/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/calculate-resources(|/)$ https://igzdocsdev.wpengine.com/$1/resources-calculate/
+# configure-security-groups/ > network-security-groups-cfg/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-security-groups(|/)$ https://igzdocsdev.wpengine.com/$1/network-security-groups-cfg/
+# configure-subnet-public-ips-alloc/ > subnet-public-ips-alloc-cfg/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/configure-subnet-public-ips-alloc(|/)$ https://igzdocsdev.wpengine.com/$1/subnet-public-ips-alloc-cfg/
+# create-iam-role/ > iam-role-n-instance-profile-create/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-role(|/)$ https://igzdocsdev.wpengine.com/$1/iam-role-n-instance-profile-create/
+# create-iam-user/ > iam-user-create/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/create-iam-user(|/)$ https://igzdocsdev.wpengine.com/$1/iam-user-create/
+# prepare-install/ > pre-install-steps/
+RedirectMatch 301 ^/(docs/latest-release/intro/setup/cloud/(aws|azure)/howto)/prepare-install(|/)$ https://igzdocsdev.wpengine.com/$1/pre-install-steps/
+


### PR DESCRIPTION
Add **.htaccess** redirect rules for recently added v2.8.0 latest-release AWS & Azure cloud installation how-tos that have now been renamed in `doc-site` [PR #2078](https://github.com/iguazio/doc-site/pull/2078) => URLs changed.